### PR TITLE
Feat/#67 page sort

### DIFF
--- a/src/app/(dashboard)/dashboard/product/_components/columns.tsx
+++ b/src/app/(dashboard)/dashboard/product/_components/columns.tsx
@@ -30,6 +30,7 @@ export const columns: ColumnDef<Product>[] = [
   {
     accessorKey: "store",
     header: "STORE",
+    enableSorting: false,
   },
   {
     accessorKey: "name",
@@ -42,10 +43,12 @@ export const columns: ColumnDef<Product>[] = [
   {
     accessorKey: "price",
     header: "PRICE",
+    sortDescFirst: true, // This column will sort in descending order first (default for number columns anyway)
   },
   {
     accessorKey: "tags",
     header: "TAGS",
+    enableSorting: false,
   },
   {
     id: "actions",

--- a/src/app/(dashboard)/dashboard/product/_components/product-table.tsx
+++ b/src/app/(dashboard)/dashboard/product/_components/product-table.tsx
@@ -11,6 +11,7 @@ import { Heading } from "@/components/ui/heading"
 import {
   PageableTable,
   PageableTableProps,
+  parseSortQueryParam,
 } from "@/components/ui/pageable-table"
 import { Separator } from "@/components/ui/separator"
 
@@ -53,6 +54,7 @@ export function ProductTable<TData, TValue>({
         columns={columns}
         totalCount={totalCount}
         data={data}
+        initailSort={parseSortQueryParam(searchParams.sort)}
         pageCount={pageCount}
       />
     </>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,9 +48,12 @@ export type MainNavItem = NavItemWithOptionalChildren
 
 export type SidebarNavItem = NavItemWithChildren
 
-type PageSearchFormValues = {
+export type SortOrder = "asc" | "desc"
+
+export type PageSearchFormValues = {
   page?: number
   limit?: number
+  sort?: string
 }
 
 export type UserSearchFormValues = {


### PR DESCRIPTION
## 概要:
商品テーブルにテーブルヘッダでのソート機能を追加

## 変更内容: 
* tanstack table の APIを用いてソート機能を実装
* 列に応じて、ソートの可否を設定
* 価格列は、DESC -> ASC の順でソートするように設定
* 汎用のpageable-tableコンポーネントを拡張

## 依頼するレビューポイント
* この部分のロジックは最適な解決策だと思いますが、より効率的なアプローチがあればご指摘ください。
* エラーハンドリングの方法について、もっと効果的なアプローチがあれば知りたいです。

## リンクや参考資料
* tenstack 公式を参考に実装
https://github.com/TanStack/table/tree/main/examples/react/sorting

## その他注意事項
* ローディング／キャッシュ制御は別チケットで対応予定
